### PR TITLE
use cheerio's XML mode

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -10,7 +10,8 @@ require('./line-highlight');
 const SELECTOR = 'pre>code[class*="language-"]';
 
 const cheerioOption = {
-    decodeEntities: false
+    decodeEntities: false,
+    xmlMode: true
 }
 
 loadLanguages('typescript');

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -122,4 +122,20 @@ div {
         expect($('pre code span.token.property').length).to.equals(1);
     });
 
+    it('should not output an <html> tag', () => {
+        let html =
+`
+<pre>
+<code class="language-markup">
+    &lt;div class="container"&gt;
+    &lt;/div&gt;
+</code>
+</pre>
+`;
+
+        let highlightedCode = target(html);
+        $ = cheerio.load(highlightedCode, {xmlMode: true});
+        expect($('html').length).to.equal(0);
+    })
+
 });


### PR DESCRIPTION
Cheerio's XML mode does not add html, head, and body tags to the output, so this eliminates the `<html> cannot appear as a child of <div>` error when using something like html-react-parser.