### PR TITLE
make prismjs a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
@@ -303,6 +304,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
       "optional": true
     },
     "diff": {
@@ -485,6 +487,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "delegate": "^3.1.2"
@@ -874,6 +877,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
       "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -918,6 +922,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
       "optional": true
     },
     "semver": {
@@ -1026,6 +1031,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
       "optional": true
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "loader-utils": "^2.0.0",
-    "lodash.mergewith": "^4.6.2",
-    "prismjs": "^1.20.0"
+    "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^7.1.2"
+    "mocha": "^7.1.2",
+    "prismjs": "^1.20.0"
+  },
+  "peerDependencies": {
+    "prismjs": "^1.20.0"
   }
 }


### PR DESCRIPTION
According to [webpack's documentation][1], prismjs should be a peer dependency.

[1]: https://webpack.js.org/contribute/writing-a-loader/#peer-dependencies