### PR TITLE
add prismjs to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Two plugins are available.
 
 ## Install
 
-1. `npm install -D prism-loader`
+```bash
+npm install -D prism-loader prismjs
+```
 
 ## Usage
 


### PR DESCRIPTION
Since prismjs is a peer dependency, include prismjs in the installation instructions.